### PR TITLE
quote μs to allow using in the browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = parse
 parse.nanosecond =
 parse.ns = 1 / 1e6
 
-parse.μs =
+parse['μs'] =
 parse.microsecond = 1 / 1e3
 
 parse.millisecond =


### PR DESCRIPTION
Quotes non-ascii `μ` character to allow use in the browser.

Having this character in strings is fine, but including it in variable/property names requires everyone using any code that contains this module in a final bundle to add `charset='utf-8'` to their script tags.

With this change they can continue omitting the charset.