### PR TITLE
Make available unit types section a heading

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -73,7 +73,7 @@ And exponents
 parse('2e3s') // => 2000 * s
 ```
 
-Available unit types are:
+#### Available unit types are:
 
 - nanoseconds (ns)
 - microseconds (μs)


### PR DESCRIPTION
Changing available unit types section a heading so that it could be referenced using a link. This will consumers of this library can reference the available unit types in their library.