### PR TITLE
Fix typings resolution when using TypeScript 4.7+ with ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "main": "./index.js",
   "exports": {
     "require": "./index.js",
-    "import": "./index.mjs"
+    "import": "./index.mjs",
+    "types": "./index.d.ts"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
TypeScript in ESM mode is trying to use file `index.d.mts` for types but there is no such file. So we need to provide custom path to typings file

For reference: same issue in another package https://github.com/telegraf/telegraf/issues/1629#issue-1248403562