### PR TITLE
Fix ESM types

### DIFF
--- a/index.d.mts
+++ b/index.d.mts
@@ -1,0 +1,4 @@
+// ./index.d.mts
+
+export * from './index.js'
+export { default } from './index.js'


### PR DESCRIPTION
This is needed for the `node16` TypeScript module resolution.