### PR TITLE
Fix the type definitions for CJS

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,22 +1,29 @@
 // ./index.d.ts
 
-/**
- * convert `str` to ms
- */
-export type Units =
-  'nanosecond' | 'ns' |
-  'µs' | 'μs' | 'us' | 'microsecond' |
-  'millisecond' | 'ms' |
-  'second' | 'sec' | 's' |
-  'minute' | 'min' | 'm' |
-  'hour' | 'hr' | 'h' |
-  'day' | 'd' |
-  'week' | 'wk' | 'w' |
-  'month' | 'b' |
-  'year' | 'yr' | 'y'
+declare namespace parse {
+  /**
+   * convert `str` to ms
+   */
+  type Units =
+    'nanosecond' | 'ns' |
+    'µs' | 'μs' | 'us' | 'microsecond' |
+    'millisecond' | 'ms' |
+    'second' | 'sec' | 's' |
+    'minute' | 'min' | 'm' |
+    'hour' | 'hr' | 'h' |
+    'day' | 'd' |
+    'week' | 'wk' | 'w' |
+    'month' | 'b' |
+    'year' | 'yr' | 'y'
+}
 
-declare const parse: ((input: string, format?: Units) => number) & {
+type Parse = {
+  (input: string, format?: parse.Units): number;
   [key: string]: number;
-};
+} & {
+  default: Parse
+}
 
-export default parse;
+declare const parse: Parse;
+
+export = parse;


### PR DESCRIPTION
Suggestion 1 from #23 was the correct approach. However, solution 2 was applied in #24. As a result, `parse` now has an index key of type number, except for the `default` property, which is a circular self reference.

As a result, the types look a bit funky, but they are now technically correct.