### PR TITLE
Add `index.d.mts` to published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,14 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "exports": {
-    "require": "./index.js",
-    "import": "./index.mjs",
-    "types": "./index.d.ts"
+    "require": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "import": {
+      "types": "./index.d.mts",
+      "default": "./index.mjs"
+    }
   },
   "dependencies": {},
   "devDependencies": {
@@ -28,7 +33,8 @@
   "files": [
     "index.js",
     "index.mjs",
-    "index.d.ts"
+    "index.d.ts",
+    "index.d.mts"
   ],
   "license": "MIT",
   "typings": "./index.d.ts"


### PR DESCRIPTION
`package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.