### PR TITLE
Fix types - use `null` instead of `undefined`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ declare namespace parse {
 }
 
 type Parse = {
-  (input: string, format?: parse.Units): number | undefined;
+  (input: string, format?: parse.Units): number | null;
   [key: string]: number;
 } & {
   default: Parse


### PR DESCRIPTION
In your code and in your tests you return `null` from the `parse` function if you cannot parse a value. But in the typings there is `undefined` type returned from the function.

Tests with null return - https://github.com/jkroso/parse-duration/blob/f959d2e7309cde7da3b4d3cffb08e09f5f7631bb/test.js#L103-L109
Code with null return - https://github.com/jkroso/parse-duration/blob/f959d2e7309cde7da3b4d3cffb08e09f5f7631bb/index.js#L70-L71