### PR TITLE
Guess next unit

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,7 +65,7 @@ parse('running length: 1hour:20mins') // => 1 * h + 20 * m
 You can even use negatives
 
 ```js
-parse('2hr -40mins') // => 1 * h + 20 * m
+parse('-1hr 40mins') // => - 1 * h + 40 * m
 ```
 
 And exponents

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function parse(str='', format='ms'){
     }
   })
 
-  return result && ((result / (unitRatio(format) || 1)) * (isNegative ? -1 : 1))
+  return result && ((result / (unitRatio(format.toLowerCase()) || 1)) * (isNegative ? -1 : 1))
 }
 
 function unitRatio(str) {

--- a/index.js
+++ b/index.js
@@ -19,8 +19,7 @@ parse.us =
 parse.microsecond = 1 / 1e3
 
 parse.millisecond =
-parse.ms =
-parse[''] = 1
+parse.ms = 1
 
 parse.second =
 parse.sec =
@@ -49,6 +48,8 @@ parse.year =
 parse.yr =
 parse.y = parse.d * 365.25
 
+var order = [parse.year, parse.month, parse.week, parse.day, parse.hour, parse.minute, parse.second, parse.millisecond, parse.microsecond, parse.nanosecond]
+
 /**
  * convert `str` to ms
  *
@@ -62,14 +63,19 @@ function parse(str='', format='ms'){
   // ignore commas/placeholders
   str = (str+'').replace(/(\d)[,_](\d)/g, '$1$2')
   var isNegative = str[0] === '-';
+  let lastUnit = 6
   str.replace(durationRE, function(_, n, units){
-    units = unitRatio(units)
-    if (units) result = (result || 0) + Math.abs(parseFloat(n, 10)) * units
+    units = units!=="" && unitRatio(units.toLowerCase())
+    if (units===false && lastUnit>=0) units = order[lastUnit + 1]
+    if (units) {
+      result = (result || 0) + Math.abs(parseFloat(n, 10)) * units
+      lastUnit = order.findIndex(u=>u===units)
+    }
   })
 
   return result && ((result / (unitRatio(format) || 1)) * (isNegative ? -1 : 1))
 }
 
 function unitRatio(str) {
-  return parse[str] || parse[str.toLowerCase().replace(/s$/, '')]
+  return parse[str] || parse[str.replace(/s$/, '')]
 }

--- a/test.js
+++ b/test.js
@@ -128,3 +128,15 @@ t('unicode support', t => {
 	t.equal(parse('5сек'), 5000)
 	t.end()
 })
+
+t('upper-case characters', t => {
+	t.equal(parse('1 MINUTE'), 60000)
+	t.equal(parse('1MS'), 1)
+	t.end()
+})
+
+t('unit guessing', t => {
+	t.equal(parse('2m30'), 150000)
+	t.equal(parse('3d 1h 15'), 3*d + h + 15*m)
+	t.end()
+})


### PR DESCRIPTION
If I say `3h50`, I meant 3 hours and 50 minutes, not 3 hours and 50 milliseconds. This pull request (passing all tests, the new tests too) fixes that issue, and an issue with capital letters (`MS` became minutes).
I'm suggesting this update because I've been using [a project](https://github.com/ChristopherBThai/Discord-OwO-Bot/tree/master) that uses this module, and I think that this will improve people's experience.