### PR TITLE
Prevent using prototype properties as units

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,10 @@ parse.nanosecond =
  */
 
 function parse(str = '', format = 'ms') {
+  if (!Object.prototype.hasOwnProperty.call(parse, format)) {
+    throw new TypeError('Invalid format "' + format + '"')
+  }
+
   var result = null, prevUnits
   // ignore commas/placeholders
   str = (str + '').replace(/(\d)[,_](\d)/g, '$1$2')
@@ -70,7 +74,13 @@ function parse(str = '', format = 'ms') {
       else units = format
     }
     else units = units.toLowerCase()
-    units = parse[units] || parse[units.replace(/s$/, '')]
+    if (Object.prototype.hasOwnProperty.call(parse, units)) {
+      units = parse[units]
+    } else if (Object.prototype.hasOwnProperty.call(parse, units.replace(/s$/, ''))) {
+      units = parse[units.replace(/s$/, '')]
+    } else {
+      units = null
+    }
     if (units) result = (result || 0) + Math.abs(parseFloat(n, 10)) * units, prevUnits = units
   })
 

--- a/test.js
+++ b/test.js
@@ -104,6 +104,8 @@ t('invalid', t => {
 	t.equal(parse('abc'), null)
 	t.equal(parse(), null)
 	t.equal(parse('I have 2 mangoes and 5 apples'), null)
+	t.equal(parse('2call 3apply'), null)
+	t.equal(parse('1arguments'), null)
 
 	t.end()
 })


### PR DESCRIPTION
If you try to use "1arguments", the code attempts to access `parse.arguments`, which throws an error in strict mode. If you try to use "2call", `parse` returns `NaN`, because it tries to use the `parse.call` function value in the calculation.

With this change, prototype properties are not considered when resolving units.