### PR TITLE
Fix: pluralization for month in Portuguese locale

### DIFF
--- a/locale/pt.js
+++ b/locale/pt.js
@@ -3,7 +3,7 @@ import en from './en.js'
 const unit = Object.create(en)
 
 unit.ano = unit.a = en.y
-unit.mês = unit.mes = en.mo
+unit.mês = unit.meses = unit.mes = en.mo
 unit.semana = unit.sem = en.w
 unit.dia = en.d
 unit.hora = en.h


### PR DESCRIPTION
The pluralization of months in Portuguese is slightly different, involving an "E" between the two "S"s.